### PR TITLE
Change logging to report the module names (instead of always root)

### DIFF
--- a/en_api.py
+++ b/en_api.py
@@ -12,48 +12,50 @@ Module of functions for echonest API management.
 
 import requests
 import logging
+logger = logging.getLogger(__name__)
+
 
 #TODO: rename to tasteprofile in place of echonest
 def echonest_favorite(api_key, profile_id, song_id):
     '''Make a song favorite in echonest tasteprofile'''
-    logging.debug('call set_echonest_favorite')
+    logger.debug('call set_echonest_favorite')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/favorite'
     payload = {"api_key": api_key,
               "id": profile_id,
               "item": str(song_id)
               }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
 
 def echonest_skip(api_key, profile_id, song_id):
     '''Skip a song favorite in echonest taste profile'''
-    logging.debug('call set_echonest_skip')
+    logger.debug('call set_echonest_skip')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/skip'
     payload = {"api_key": api_key,
               "id": profile_id,
               "item": str(song_id)
               }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
 
 def echonest_info(api_key, profile_id):
     '''Display info about echonest profile'''
-    logging.debug('call echonest_info')
+    logger.debug('call echonest_info')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/profile'
     payload = {"api_key": api_key,
               "id": profile_id
               }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
     ret = r.json()
     return ret['response']['catalog']
 
 def echonest_read(api_key, profile_id, item_id):
     '''Display dat about a given item'''
-    logging.debug('call echonest_read')
+    logger.debug('call echonest_read')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/read'
     payload = {
             'api_key': api_key,
@@ -65,14 +67,14 @@ def echonest_read(api_key, profile_id, item_id):
                 ]
             }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
     ret = r.json()
     return ret['response']['catalog']['items'][0]
 
 def echonest_delete(api_key, profile_id):
     '''Delete echonest tasteprofile'''
-    logging.debug('call echonest_delete')
+    logger.debug('call echonest_delete')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/delete'
     headers = {'content-type': 'multipart/form-data'}
     payload = {"api_key": api_key,

--- a/fancy_disp.py
+++ b/fancy_disp.py
@@ -10,11 +10,13 @@ Module of display function for PyKodi.
 '''
 
 import logging
+logger = logging.getLogger(__name__)
+
 
 #TODO: song_ids and not songs_id + just albums or songs
 def albums_index(albums_id, kodi_albums):
     '''Display albums list from internal index'''
-    logging.debug('call disp_albums_index')
+    logger.debug('call disp_albums_index')
     print
     for i, album_id in enumerate(albums_id):
         print ("%02i. %s by %s (%s) [%i]") % (
@@ -29,7 +31,7 @@ def albums_index(albums_id, kodi_albums):
 
 def songs_index(songs_id, kodi_songs):
     '''Display songs list from internal index'''
-    logging.debug('call disp_songs_index')
+    logger.debug('call disp_songs_index')
     print
     for i, song_id in enumerate(songs_id):
         print ("%02i. \"%s\" by %s (%s) [%i]") % (
@@ -41,7 +43,7 @@ def songs_index(songs_id, kodi_songs):
 
 def songs_details(song_id, kodi_songs):
     '''Display song details from song id'''
-    logging.debug('call disp_songs_details')
+    logger.debug('call disp_songs_details')
     print
     print ("%s by %s (%s)") % (
             kodi_songs[song_id]['title'],

--- a/kodi_api.py
+++ b/kodi_api.py
@@ -12,6 +12,7 @@ Module of functions for Kodi API management.
 import requests
 import json
 import logging
+logger = logging.getLogger(__name__)
 
 # API call management
 
@@ -26,8 +27,8 @@ def call_api(server_params, command):
     return ret
 
 def call_api_http(server_params, command):
-    logging.debug('call call_api_http')
-    logging.debug('command: %s', command)
+    logger.debug('call call_api_http')
+    logger.debug('command: %s', command)
     kodi_url = 'http://' + server_params['ip'] +  ':' + str(server_params['port']) + '/jsonrpc'
     headers = {'Content-Type': 'application/json'}
     r = requests.post(
@@ -36,42 +37,42 @@ def call_api_http(server_params, command):
             headers=headers,
             auth=(server_params['user'], server_params['password']))
     ret = r.json()
-    logging.debug('url: %s', r.url)
-    logging.debug('status code: %s', r.status_code)
-    logging.debug('text: %s', r.text)
+    logger.debug('url: %s', r.url)
+    logger.debug('status code: %s', r.status_code)
+    logger.debug('text: %s', r.text)
     return ret
 
 def call_api_tcp(ip, port, command):
     '''Send the command using TCP'''
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((ip, port))
-    logging.debug('command: %s', command)
+    logger.debug('command: %s', command)
     s.send(json.dumps(command))
     data = ''
     while True:
         filler = s.recv(BUFFER_SIZE)
-        logging.debug('data received: %s', filler)
-        logging.debug('length of the filler: %i', len(filler))
+        logger.debug('data received: %s', filler)
+        logger.debug('length of the filler: %i', len(filler))
         data += filler
         nb_open_brackets = data.count('{') - data.count('}')
-        logging.debug('number of open brackets: %i', nb_open_brackets)
+        logger.debug('number of open brackets: %i', nb_open_brackets)
         if nb_open_brackets == 0:
             break
         else:
-            logging.info('api reception incomplete')
+            logger.info('api reception incomplete')
     s.close()
-    logging.debug('data length: %i', len(data))
+    logger.debug('data length: %i', len(data))
     ret = json.loads(data)
-    logging.debug('return: %s', ret)
+    logger.debug('return: %s', ret)
 
 def display_result(ret):
     '''Display command result for simple methods'''
-    logging.debug('call display_result')
+    logger.debug('call display_result')
     if 'error' in ret:
-        logging.error('too bad, something went wrong!')
-        logging.error('error message: %s', ret['error']['message'])
+        logger.error('too bad, something went wrong!')
+        logger.error('error message: %s', ret['error']['message'])
     else:
-        logging.info('command processed successfully')
+        logger.info('command processed successfully')
 
 # audiolibrary
 
@@ -107,7 +108,7 @@ def audiolibrary_get_songs(server_params, song_id_start, song_id_end):
 
 def playlist_add(item_type, item_id, server_params):
     '''Add an item to the audio playlist'''
-    logging.debug('call function playlist_add')
+    logger.debug('call function playlist_add')
     command = {"jsonrpc": "2.0",
             "method": "Playlist.Add",
             "params": {
@@ -120,7 +121,7 @@ def playlist_add(item_type, item_id, server_params):
 
 def playlist_clear(server_params):
     '''Clear the audio playlist'''
-    logging.debug('call function playlist_clear')
+    logger.debug('call function playlist_clear')
     command = {"jsonrpc": "2.0",
             "method": "Playlist.Clear",
             "params": {
@@ -132,7 +133,7 @@ def playlist_clear(server_params):
 def playlist_get_items(server_params):
     '''Get all items from the audio playlist'''
     #TODO: change to return the item id only
-    logging.debug('call playlist_get_items')
+    logger.debug('call playlist_get_items')
     command = {"jsonrpc": "2.0",
             "method": "Playlist.GetItems",
             "params": {
@@ -145,7 +146,7 @@ def playlist_get_items(server_params):
     try:
         for item in ret['result']['items']:
             items.append(item['id'])
-        logging.debug('items in the playlist: %s', items)
+        logger.debug('items in the playlist: %s', items)
     except KeyError:
         pass
     return items
@@ -154,7 +155,7 @@ def playlist_get_items(server_params):
 
 def player_get_active(server_params):
     '''Returns active audio players (boolean)'''
-    logging.debug('call function player_get_active')
+    logger.debug('call function player_get_active')
     command = {"jsonrpc": "2.0",
             "method": "Player.GetActivePlayers",
             "id": 1,
@@ -165,13 +166,13 @@ def player_get_active(server_params):
     for player in ret ['result']:
         if player['playerid'] == 0:
             is_active = True
-    logging.debug('active audio player: %s', is_active)
+    logger.debug('active audio player: %s', is_active)
     return is_active
 
 def player_get_item(server_params):
     '''Get the current played item'''
     #TODO: change to return item id only
-    logging.debug('call function get_item')
+    logger.debug('call function get_item')
     command = {"jsonrpc": "2.0",
             "method": "Player.GetItem",
             "params": {
@@ -187,7 +188,7 @@ def player_get_item(server_params):
 
 def player_get_properties(server_params):
     '''Get properties of the played item'''
-    logging.debug('call function player_get_properties')
+    logger.debug('call function player_get_properties')
     command = {"jsonrpc": "2.0",
             "method": "Player.GetProperties",
             "params": {
@@ -203,13 +204,13 @@ def player_get_properties(server_params):
     if 'result' in ret:
         result = ret['result']
     else:
-        logging.debug('no properties found, player not active')
+        logger.debug('no properties found, player not active')
         result = None
     return result
 
 def player_goto(server_params):
     '''Go to the next item'''
-    logging.debug('call function player_goto')
+    logger.debug('call function player_goto')
     command = {"jsonrpc": "2.0",
             "method": "Player.GoTo",
             "params":{
@@ -221,7 +222,7 @@ def player_goto(server_params):
 
 def player_open(server_params):
     '''Open the audio playlist'''
-    logging.debug('call function player_open')
+    logger.debug('call function player_open')
     command = {"jsonrpc": "2.0",
             "method": "Player.Open",
             "params": {
@@ -234,7 +235,7 @@ def player_open(server_params):
 
 def player_open_party(server_params):
     '''Open the audio player in partymode'''
-    logging.debug('call function player_open_party')
+    logger.debug('call function player_open_party')
     command = {"jsonrpc": "2.0",
             "method": "Player.Open",
             "params": {
@@ -247,7 +248,7 @@ def player_open_party(server_params):
 
 def player_play_pause(server_params):
     '''Pauses or unpause playback'''
-    logging.debug('call function player_play_pause')
+    logger.debug('call function player_play_pause')
     command = {"jsonrpc": "2.0",
             "method": "Player.PlayPause",
             "params": {
@@ -259,7 +260,7 @@ def player_play_pause(server_params):
 
 def player_stop(server_params):
     '''Stop playback'''
-    logging.debug('call function player_stop')
+    logger.debug('call function player_stop')
     command = {"jsonrpc": "2.0",
             "method": "Player.Stop",
             "params": {
@@ -272,7 +273,7 @@ def player_stop(server_params):
 
 def player_volume(server_params,volume):
     '''Volume'''
-    logging.debug('call function player_volume')
+    logger.debug('call function player_volume')
     command = {"jsonrpc": "2.0",
             "method": "Application.SetVolume",
             "params": {

--- a/pykodi.py
+++ b/pykodi.py
@@ -26,6 +26,8 @@ import logging
 import argparse
 from sys import exit
 
+logger = logging.getLogger(__name__)
+
 # global constants
 BUFFER_SIZE = 1024
 DISPLAY_NB_LINES = 10
@@ -70,19 +72,19 @@ def get_pykodi_params():
     server_params['user'] = args.user
     server_params['password'] = args.password
     if args.verbosity == 2:
-        logging.basicConfig(level=logging.DEBUG)
+        logger.basicConfig(level=logger.DEBUG)
     else:
         if args.verbosity == 1:
-            logging.basicConfig(level=logging.INFO)
-    logging.info('Kodi controller started in verbosity mode ...')
-    logging.debug('... and even in high verbosity mode!')
+            logger.basicConfig(level=logger.INFO)
+    logger.info('Kodi controller started in verbosity mode ...')
+    logger.debug('... and even in high verbosity mode!')
     return server_params, args.echonest_key, args.command
 
 # local files
 
 def is_file(fname):
     '''Return false if the file does not exist'''
-    logging.debug('call function is_file')
+    logger.debug('call function is_file')
     try:
         open(fname)
     except IOError:
@@ -91,17 +93,17 @@ def is_file(fname):
 
 def is_library_files():
     '''Check if there are library local files'''
-    logging.debug('call function is_library_files')
+    logger.debug('call function is_library_files')
     ret = True
     ret = ret and is_file('albums.pickle')
     ret = ret and is_file('songs.pickle')
-    logging.info('library files check: %s', ret)
+    logger.info('library files check: %s', ret)
     return ret
 
 def get_audio_library(obj):
     '''Manage lists for audio library, from a local file or the server'''
-    logging.debug('call function get_audio_library')
-    logging.debug('load albums library in memory')
+    logger.debug('call function get_audio_library')
+    logger.debug('load albums library in memory')
     if is_library_files():
         get_audio_library_from_files(obj)
     else:
@@ -109,21 +111,21 @@ def get_audio_library(obj):
 
 def save_songs(songs):
     '''Save songs to local files'''
-    logging.debug('call function save_songs')
+    logger.debug('call function save_songs')
     f = open('songs.pickle', 'wb')
     pickle.dump(songs, f)
     f.close()
 
 def save_albums(albums):
     '''Save albums to local files'''
-    logging.debug('call function save_albums')
+    logger.debug('call function save_albums')
     f = open('albums.pickle', 'wb')
     pickle.dump(albums, f)
     f.close()
 
 def get_audio_library_from_files(obj):
     '''Load the library in memory from local files'''
-    logging.debug('call function get_audio_library_from_files')
+    logger.debug('call function get_audio_library_from_files')
     f = open('songs.pickle', 'rb')
     obj.songs = pickle.load(f)
     f.close()
@@ -135,13 +137,13 @@ def get_audio_library_from_files(obj):
 
 def get_audio_library_from_server(obj):
     '''Load the library in memory from the Kodi server'''
-    logging.debug('get_audio_library_from_server')
+    logger.debug('get_audio_library_from_server')
     print "Loading the Kodi server library, this may be very long"
     print
     # Loading songs
     songs_dummy = kodi_api.audiolibrary_get_songs(obj.kodi_params, 0, 1)
     nb_songs = songs_dummy['limits']['total']
-    logging.debug('number of songs: %i', nb_songs)
+    logger.debug('number of songs: %i', nb_songs)
     obj.nb_songs = nb_songs
     widgets = [
         'Songs: ', Percentage(),
@@ -154,7 +156,7 @@ def get_audio_library_from_server(obj):
     if not limits[-1] == nb_songs:
         limits.append(nb_songs)
     for start, end in zip(limits[:-1], limits[1:]):
-        logging.info('Processing song %i to %i ...', start, end)
+        logger.info('Processing song %i to %i ...', start, end)
         pbar.update(start)
         while True:
             try:
@@ -193,13 +195,13 @@ def get_audio_library_from_server(obj):
                 break
             except KeyError:
                 #TODO: improve error catching, limit to API errors
-                logging.info('error when loading library, retry')
+                logger.info('error when loading library, retry')
     pbar.finish()
     save_songs(obj.songs)
     # Loading albums
     albums_dummy = kodi_api.audiolibrary_get_albums(obj.kodi_params, 0, 1)
     nb_albums = albums_dummy['limits']['total']
-    logging.debug('number of albums: %i', nb_albums)
+    logger.debug('number of albums: %i', nb_albums)
     obj.nb_albums = nb_albums
     widgets = [
         'Albums: ', Percentage(),
@@ -212,7 +214,7 @@ def get_audio_library_from_server(obj):
     if not limits[-1] == nb_albums:
         limits.append(nb_albums)
     for start, end in zip(limits[:-1], limits[1:]):
-        logging.info('Processing album %i to %i ...', start, end)
+        logger.info('Processing album %i to %i ...', start, end)
         pbar.update(start)
         while True:
             try:
@@ -236,7 +238,7 @@ def get_audio_library_from_server(obj):
                     obj.albums[album['albumid']]['year'] = album['year']
                 break
             except KeyError:
-                logging.info('error when loading library, retry')
+                logger.info('error when loading library, retry')
     pbar.finish()
     save_albums(obj.albums)
     print
@@ -245,7 +247,7 @@ def get_audio_library_from_server(obj):
 
 def parse_single_int(line):
     '''Parse line for a single int'''
-    logging.debug('call function parse_single_int')
+    logger.debug('call function parse_single_int')
     args = str.split(line)
     ret_val = None
     try:
@@ -287,8 +289,8 @@ def get_albums_search(search_string, albums):
             search_result_title.append(album_id)
         if search_string in albums[album_id]['artist'].lower():
             search_result_artist.append(album_id)
-    logging.debug('search result by title: %s', search_result_title)
-    logging.debug('search result by artist: %s', search_result_artist)
+    logger.debug('search result by title: %s', search_result_title)
+    logger.debug('search result by artist: %s', search_result_artist)
     return sorted(list(set(search_result_title + search_result_artist)))
 
 def get_songs_search(search_string, songs):
@@ -300,8 +302,8 @@ def get_songs_search(search_string, songs):
             search_result_title.append(song_id)
         if search_string in songs[song_id]['artist'].lower():
             search_result_artist.append(song_id)
-    logging.debug('search result by title: %s', search_result_title)
-    logging.debug('search result by artist: %s', search_result_artist)
+    logger.debug('search result by title: %s', search_result_title)
+    logger.debug('search result by artist: %s', search_result_artist)
     return sorted(list(set(search_result_title + search_result_artist)))
 
 def get_genre_search(search_string, songs):
@@ -311,17 +313,17 @@ def get_genre_search(search_string, songs):
         for genre in songs[song_id]['genre']:
             if search_string.lower() == genre.lower(): #Exact match is wanted, otherwise "Classic" is not distinguishable form "Classic Rock". 
                 search_result_genre.append(song_id)
-    logging.debug('search result by genre: %s', search_result_genre)
+    logger.debug('search result by genre: %s', search_result_genre)
     return sorted(list(search_result_genre))
 
 def set_songs_sync(server_params, songs):
     '''Sync playcount and rating'''
-    logging.debug('call set_songs_sync')
+    logger.debug('call set_songs_sync')
     print
     print "Updating songs rating and playcount (could be long)"
     print
     nb_songs = len(songs)
-    logging.debug('number of songs: %i', nb_songs)
+    logger.debug('number of songs: %i', nb_songs)
     widgets = [
              'Songs: ', Percentage(),
              ' ', Bar(marker='#',left='[',right=']'),
@@ -335,7 +337,7 @@ def set_songs_sync(server_params, songs):
     if not limits[-1] == nb_songs:
         limits.append(nb_songs)
     for start, end in zip(limits[:-1], limits[1:]):
-        logging.info('Processing song %i to %i ...', start, end)
+        logger.info('Processing song %i to %i ...', start, end)
         pbar.update(start)
         while True:
             #TODO: use an API function
@@ -354,20 +356,20 @@ def set_songs_sync(server_params, songs):
                 ret = kodi_api.call_api(server_params, command)
                 for r_song in ret['result']['songs']:
                     if songs[r_song['songid']]['rating'] != r_song['rating']:
-                        logging.info(
+                        logger.info(
                                 'updating rating for %s!',
                                 r_song['songid'])
                         songs[r_song['songid']]['rating'] = r_song['rating']
                         nb_update_rating += 1
                     if songs[r_song['songid']]['playcount'] != r_song['playcount']:
-                        logging.info(
+                        logger.info(
                                 'updating playcount for %s!',
                                 r_song['songid'])
                         songs[r_song['songid']]['playcount'] = r_song['playcount']
                         nb_update_playcount += 1
                 break
             except KeyError:
-                logging.info('error when loading library, retry')
+                logger.info('error when loading library, retry')
     pbar.finish()
     save_songs(songs)
     print
@@ -377,7 +379,7 @@ def set_songs_sync(server_params, songs):
 
 def get_profile_delta(songs):
     '''Songs id with echonest rating and playcount not up-to-date'''
-    logging.debug('call get_profile_delta')
+    logger.debug('call get_profile_delta')
     songs_id_delta = []
     for song_id in songs.keys():
         if not songs[song_id]['rating'] == songs[song_id]['rating_en']:
@@ -390,22 +392,22 @@ def get_profile_delta(songs):
 
 def echonest_sync(api_key, profile_id, songs):
     '''Sync songs with echonest tasteprofile'''
-    logging.debug('call echonest_sync')
+    logger.debug('call echonest_sync')
     #TODO: cache the profile ID
     #TODO: create routines for echonest API calls + HTTP Kodi calls
     en_info = en_api.echonest_info(api_key, profile_id)
     if en_info['total'] == 0:
-        logging.info("no songs in tasteprofile, full sync")
+        logger.info("no songs in tasteprofile, full sync")
         songs_id_delta = songs.keys()
     else:
-        logging.info("limit sync to delta")
+        logger.info("limit sync to delta")
         songs_id_delta = get_profile_delta(songs)
     nb_songs_delta = len(songs_id_delta)
     print
     print "Sync songs to the tasteprofile (this can be very very long)"
     print
-    logging.info('delta size: %i', nb_songs_delta)
-    logging.debug('delta songs %s', songs_id_delta)
+    logger.info('delta size: %i', nb_songs_delta)
+    logger.debug('delta songs %s', songs_id_delta)
     widgets = [
             'Songs: ', Percentage(),
             ' ', Bar(marker='#',left='[',right=']'),
@@ -418,7 +420,7 @@ def echonest_sync(api_key, profile_id, songs):
     if not limits[-1] == nb_songs_delta:
         limits.append(nb_songs_delta)
     for start, end in zip(limits[:-1], limits[1:]):
-        logging.info('Processing song index from  %i to %i ...', start, end)
+        logger.info('Processing song index from  %i to %i ...', start, end)
         pbar.update(start)
         command = []
         songs_index_slice = range(start, end)
@@ -445,12 +447,12 @@ def echonest_sync(api_key, profile_id, songs):
                 'api_key': api_key,
                 'id': profile_id,
                 'data': json.dumps(command)}
-        logging.debug('command: %s', command)
+        logger.debug('command: %s', command)
         r = requests.post(url, headers=headers, params=payload)
         if r.status_code == 200:
-            logging.debug('return: %s', r.text)
+            logger.debug('return: %s', r.text)
         else:
-            logging.error('return: %s', r.text)
+            logger.error('return: %s', r.text)
         time.sleep(0.51)
     pbar.finish()
     save_songs(songs)
@@ -458,7 +460,7 @@ def echonest_sync(api_key, profile_id, songs):
 
 def echonest_playlist(api_key, profile_id):
     '''Create a premium static playlist'''
-    logging.debug('call echonest_playlist')
+    logger.debug('call echonest_playlist')
     #TODO: split in API function + conversion of namespace
     print
     print "Requesting a playlist to echonest ..."
@@ -469,8 +471,8 @@ def echonest_playlist(api_key, profile_id):
               "bucket": 'id:' + profile_id
               }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
     ret = r.json()
     en_songs = ret['response']['songs']
     playlist = []
@@ -482,7 +484,7 @@ def echonest_playlist(api_key, profile_id):
 
 def echonest_pl_seed(api_key, profile_id, song_id):
     '''Create a premium static playlist seeded by a song'''
-    logging.debug('call echonest_pl_song')
+    logger.debug('call echonest_pl_song')
     #TODO: split in API function + conversion of namespace
     print
     print "Requesting a playlist to echonest ..."
@@ -495,8 +497,8 @@ def echonest_pl_seed(api_key, profile_id, song_id):
               "bucket": 'id:' + profile_id
               }
     r = requests.get(url, params=payload)
-    logging.debug('URL: %s', r.url)
-    logging.debug('return: %s', r.text)
+    logger.debug('URL: %s', r.url)
+    logger.debug('return: %s', r.text)
     ret = r.json()
     en_songs = ret['response']['songs']
     playlist = []
@@ -509,14 +511,14 @@ def echonest_pl_seed(api_key, profile_id, song_id):
 def get_profile_id(api_key):
     '''Get echonest profile profile ID'''
     #TODO: split in unit API functions
-    logging.debug('call get_profile_id')
+    logger.debug('call get_profile_id')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/profile'
     payload = {
             'api_key': api_key,
             'name': PROFILE_NAME}
     r = requests.get(url, params=payload)
     if r.status_code == 400:
-        logging.debug('no taste profile found')
+        logger.debug('no taste profile found')
         url = 'http://developer.echonest.com/api/v4/tasteprofile/create'
         headers = {'content-type': 'multipart/form-data'}
         payload = {
@@ -527,23 +529,23 @@ def get_profile_id(api_key):
         ret = r.json()
         profile_id = ret['response']['id']
     else:
-        logging.debug('taste profile found')
+        logger.debug('taste profile found')
         ret = r.json()
         profile_id = ret['response']['catalog']['id'] 
-    logging.debug('return: %s', r.text)
-    logging.debug('profile id: %s', profile_id)
+    logger.debug('return: %s', r.text)
+    logger.debug('profile id: %s', profile_id)
     return profile_id
 def get_profile_id(api_key):
     '''Get echonest profile profile ID'''
     #TODO: split in unit API functions
-    logging.debug('call get_profile_id')
+    logger.debug('call get_profile_id')
     url = 'http://developer.echonest.com/api/v4/tasteprofile/profile'
     payload = {
             'api_key': api_key,
             'name': PROFILE_NAME}
     r = requests.get(url, params=payload)
     if r.status_code == 400:
-        logging.debug('no taste profile found')
+        logger.debug('no taste profile found')
         url = 'http://developer.echonest.com/api/v4/tasteprofile/create'
         headers = {'content-type': 'multipart/form-data'}
         payload = {
@@ -554,16 +556,16 @@ def get_profile_id(api_key):
         ret = r.json()
         profile_id = ret['response']['id']
     else:
-        logging.debug('taste profile found')
+        logger.debug('taste profile found')
         ret = r.json()
         profile_id = ret['response']['catalog']['id'] 
-    logging.debug('return: %s', r.text)
-    logging.debug('profile id: %s', profile_id)
+    logger.debug('return: %s', r.text)
+    logger.debug('profile id: %s', profile_id)
     return profile_id
 
 def playback(kodi_params):
     '''Start playback'''
-    logging.debug('call function playback')
+    logger.debug('call function playback')
     if kodi_api.player_get_active(kodi_params):
         kodi_api.player_play_pause(kodi_params)
     else:
@@ -571,7 +573,7 @@ def playback(kodi_params):
 
 def playback_stop(kodi_params):
     '''Start playback'''
-    logging.debug('call function playback stop')
+    logger.debug('call function playback stop')
     if kodi_api.player_get_active(kodi_params):
         kodi_api.player_stop(kodi_params)
 
@@ -611,7 +613,7 @@ class KodiRemote(cmd.Cmd):
         
         ''' Check if we skip command line and directly execute the passed command'''
         if self.command!=0:
-            logging.info("Executing custom command")
+            logger.info("Executing custom command")
             self.onecmd(self.command)                
             #TODO find out how to detect errors.
             quit()
@@ -628,7 +630,7 @@ class KodiRemote(cmd.Cmd):
         Display a random selection of albums
         Usage: albums_random
         '''
-        logging.debug('call function do_albums_random')
+        logger.debug('call function do_albums_random')
         albums_pos = random.sample(xrange(self.nb_albums), DISPLAY_NB_LINES)
         fancy_disp.albums_index(albums_pos, self.albums)
 
@@ -638,20 +640,20 @@ class KodiRemote(cmd.Cmd):
         Usage: albums_page [page]
             The page is optional, a random page is displayed without it.
         '''
-        logging.debug('call function do_albums_page')
+        logger.debug('call function do_albums_page')
         page_nb = parse_single_int(line)
         if not page_nb:
-            logging.info('no page number provided')
+            logger.info('no page number provided')
             page_nb = random.randrange(int(self.nb_albums / 10) + 1)
         albums_pos = range(
                 (page_nb - 1) * DISPLAY_NB_LINES,
                 page_nb * DISPLAY_NB_LINES)
-        logging.debug('albums index range: %s', albums_pos)
+        logger.debug('albums index range: %s', albums_pos)
         # clean this conversion
         album_ids = []
         for album_pos in albums_pos:
             album_ids.append(self.albums.keys()[album_pos])
-        logging.debug('albums id range: %s', album_ids)
+        logger.debug('albums id range: %s', album_ids)
         fancy_disp.albums_index(album_ids, self.albums)
 
     def do_albums_recent(self, line):
@@ -659,7 +661,7 @@ class KodiRemote(cmd.Cmd):
         Display recently added albums
         Usage: albums_recent
         '''
-        logging.debug('call function do_albums_recent')
+        logger.debug('call function do_albums_recent')
         albums_pos = range(
                 self.nb_albums + 1 - DISPLAY_NB_LINES, 
                 self.nb_albums + 1)
@@ -671,7 +673,7 @@ class KodiRemote(cmd.Cmd):
         Usage: albums_search string
             List all albums containing the string in the title or artist.
         '''
-        logging.debug('call function do_albums_search')
+        logger.debug('call function do_albums_search')
         search_string = line.lower()
         #TODO: general refactor to album_ids (pos should not be used)
         albums_pos = get_albums_search(search_string, self.albums)
@@ -685,10 +687,10 @@ class KodiRemote(cmd.Cmd):
         Usage: songss_page [page]
             The page is optional, a random page is displayed without it.
         '''
-        logging.debug('call function do_songs_page')
+        logger.debug('call function do_songs_page')
         page_nb = parse_single_int(line)
         if not page_nb:
-            logging.info('no page number provided')
+            logger.info('no page number provided')
             page_nb = random.randrange(int(self.nb_songs / 10) + 1)
         songs_pos = range(
                 (page_nb - 1) * DISPLAY_NB_LINES + 1,
@@ -702,7 +704,7 @@ class KodiRemote(cmd.Cmd):
             Display all information about a given song like the playcount
             or the rating.
         '''
-        logging.debug('call function do_song_display')
+        logger.debug('call function do_song_display')
         song_id = parse_single_int(line)
         fancy_disp.songs_details(song_id, self.songs)
     
@@ -712,7 +714,7 @@ class KodiRemote(cmd.Cmd):
         Usage: songs_search string
             List all songs containing the string in the title or artist.
         '''
-        logging.debug('call function do_songs_search')
+        logger.debug('call function do_songs_search')
         search_string = line.lower()
         songs_pos = get_songs_search(search_string, self.songs)
         fancy_disp.songs_index(songs_pos, self.songs)
@@ -723,7 +725,7 @@ class KodiRemote(cmd.Cmd):
         Usage: songs_sync
             Sync playcount and rating from the Kodi server to PyKodi.
         '''
-        logging.debug('call function do_songs_sync')
+        logger.debug('call function do_songs_sync')
         set_songs_sync(self.kodi_params, self.songs)
     
     # playlist functions
@@ -733,7 +735,7 @@ class KodiRemote(cmd.Cmd):
         Show the current audio playlist
         Usage: playlist_show
         '''
-        logging.debug('call function do_playlist_show')
+        logger.debug('call function do_playlist_show')
         if kodi_api.player_get_active(self.kodi_params):
             properties = kodi_api.player_get_properties(self.kodi_params)
         else:
@@ -749,10 +751,10 @@ class KodiRemote(cmd.Cmd):
             Use the albums function to find the id.
             The id is optional, an album is randomly selected without it.
         '''
-        logging.debug('call function do_playlist_add')
+        logger.debug('call function do_playlist_add')
         album_id = parse_single_int(line)
         if not album_id:
-            logging.info('no album id provided')
+            logger.info('no album id provided')
             album_id = random.randrange(self.nb_albums)
             #TODO: disp function
             print
@@ -766,7 +768,7 @@ class KodiRemote(cmd.Cmd):
         Usage: playlist_clear
             Remove all items from the current playlist.
         '''
-        logging.debug('call function do_playlist_clear')
+        logger.debug('call function do_playlist_clear')
         kodi_api.playlist_clear(self.kodi_params)
 
     def do_playlist_tasteprofile(self, line):
@@ -777,7 +779,7 @@ class KodiRemote(cmd.Cmd):
             echonest taste profile. The current playlist
             is removed before.
         '''
-        logging.debug('call function do_playlist_tasteprofile')
+        logger.debug('call function do_playlist_tasteprofile')
         profile_id = get_profile_id(self.api_key)
         while True:
             song_ids = echonest_playlist(self.api_key, profile_id)
@@ -801,7 +803,7 @@ class KodiRemote(cmd.Cmd):
             is removed before.
         '''
         #TODO: function for a single logic and several pl methods
-        logging.debug('call function do_playlist_tasteprofile')
+        logger.debug('call function do_playlist_tasteprofile')
         song_id = parse_single_int(line)
         profile_id = get_profile_id(self.api_key)
         while True:
@@ -827,12 +829,12 @@ class KodiRemote(cmd.Cmd):
             Use the albums function to find the id.
             The id is optional, an album is randomly selected without it.
         '''
-        logging.debug('call function do_play_album')
+        logger.debug('call function do_play_album')
         album_id = parse_single_int(line)
         if not album_id:
-            logging.info('no album id provided')
+            logger.info('no album id provided')
             album_index = random.randrange(self.nb_albums)
-            logging.debug('random album index: %i', album_index)
+            logger.debug('random album index: %i', album_index)
             album_id = self.albums.keys()[album_index]
         kodi_api.playlist_clear(self.kodi_params)
         kodi_api.playlist_add(ALBUM, album_id, self.kodi_params)
@@ -846,7 +848,7 @@ class KodiRemote(cmd.Cmd):
         Start a big party!
         Usage: play_party
         '''
-        logging.debug('call function do_play_party')
+        logger.debug('call function do_play_party')
         kodi_api.player_open_party(self.kodi_params)
 
     def do_play_pause(self, line):
@@ -855,7 +857,7 @@ class KodiRemote(cmd.Cmd):
         Usage: play_pause
             Switch to pause if playing, switch to play if in pause.
         '''
-        logging.debug('call function do_play_pause')
+        logger.debug('call function do_play_pause')
         playback(self.kodi_params)
 
     def do_play_stop(self, line):
@@ -864,7 +866,7 @@ class KodiRemote(cmd.Cmd):
         Usage: play_stop
             Stop the music and go home, I repeat, stop the music and go home.
         '''
-        logging.debug('call function do_play_stop')
+        logger.debug('call function do_play_stop')
         playback_stop(self.kodi_params)
 
     def do_play_what(self, line):
@@ -872,7 +874,7 @@ class KodiRemote(cmd.Cmd):
         Detail status of what is currently played
         Usage: play_what
         '''
-        logging.debug('call function do_play_what')
+        logger.debug('call function do_play_what')
         item = kodi_api.player_get_item(self.kodi_params)
         properties = kodi_api.player_get_properties(self.kodi_params)
         items = kodi_api.playlist_get_items(self.kodi_params)
@@ -884,7 +886,7 @@ class KodiRemote(cmd.Cmd):
         Like the current song (in your echonest tasteprofile)
         Usage: play_favorite
         '''
-        logging.debug('call function do_play_favorite')
+        logger.debug('call function do_play_favorite')
         song_id = kodi_api.player_get_item(self.kodi_params)
         profile_id = get_profile_id(self.api_key)
         en_api.echonest_favorite(self.api_key, profile_id, song_id)
@@ -897,7 +899,7 @@ class KodiRemote(cmd.Cmd):
         Skip the current song
         Usage: play_skip
         '''
-        logging.debug('call function do_play_skip')
+        logger.debug('call function do_play_skip')
         song_id = kodi_api.player_get_item(self.kodi_params)
         profile_id = get_profile_id(self.api_key)
         kodi_api.player_goto(self.kodi_params)
@@ -912,7 +914,7 @@ class KodiRemote(cmd.Cmd):
         Usage: play_genre [genre]
             The library is search for all songs with playlist is shuffled each time
         '''
-        logging.debug('call function do_play_genre')
+        logger.debug('call function do_play_genre')
         song_ids=get_genre_search(line, self.songs)
         #Listening to the same sequence is bornig, so shuffle the list each time. 
         random.shuffle(song_ids)
@@ -930,12 +932,12 @@ class KodiRemote(cmd.Cmd):
        Set volume in percent
        Usage: volume 100
        '''
-       logging.debug('call function do_volume')
+       logger.debug('call function do_volume')
        #TODO percent might not be a number between 0 and 100
        try:            
            kodi_api.player_volume(self.kodi_params,int(percent))
        except:
-           logging.error('Volume must be between 0 and 100.')
+           logger.error('Volume must be between 0 and 100.')
 
     # echonest functions
 
@@ -944,7 +946,7 @@ class KodiRemote(cmd.Cmd):
         Sync play count and rating with echonest taste profile
         Usage: echonest_sync
         '''
-        logging.debug('call function do_echonest_sync')
+        logger.debug('call function do_echonest_sync')
         profile_id = get_profile_id(self.api_key)
         echonest_sync(self.api_key, profile_id, self.songs)
         
@@ -953,7 +955,7 @@ class KodiRemote(cmd.Cmd):
         Display info about the echonest taste profile.
         Usage: echonest_info
         '''
-        logging.debug('call function do_echonest_info')
+        logger.debug('call function do_echonest_info')
         profile_id = get_profile_id(self.api_key)
         en_info = en_api.echonest_info(self.api_key, profile_id)
         #TODO: create disp function
@@ -966,7 +968,7 @@ class KodiRemote(cmd.Cmd):
         Display data for a given item.
         Usage: echonest_read item_id
         '''
-        logging.debug('call function do_echonest_info')
+        logger.debug('call function do_echonest_info')
         profile_id = get_profile_id(self.api_key)
         item_id = parse_single_int(line)
         song_data = en_api.echonest_read(self.api_key, profile_id, item_id)
@@ -979,7 +981,7 @@ class KodiRemote(cmd.Cmd):
         Delete echonest taste profile.
         Usage: echonest_delete
         '''
-        logging.debug('call function do_echonest_delete')
+        logger.debug('call function do_echonest_delete')
         profile_id = get_profile_id(self.api_key)
         if fancy_disp.sure_delete_tasteprofile(self.api_key, profile_id):
         #TODO: insert a validation prompt
@@ -987,7 +989,7 @@ class KodiRemote(cmd.Cmd):
 
     def do_EOF(self, line):
         '''Override end of file'''
-        logging.info('Bye!')
+        logger.info('Bye!')
         print 'Bye!'
         return True
 

--- a/pykodi.py
+++ b/pykodi.py
@@ -72,10 +72,10 @@ def get_pykodi_params():
     server_params['user'] = args.user
     server_params['password'] = args.password
     if args.verbosity == 2:
-        logger.basicConfig(level=logger.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
     else:
         if args.verbosity == 1:
-            logger.basicConfig(level=logger.INFO)
+            logging.basicConfig(level=logging.INFO)
     logger.info('Kodi controller started in verbosity mode ...')
     logger.debug('... and even in high verbosity mode!')
     return server_params, args.echonest_key, args.command


### PR DESCRIPTION
1. rename 'logging' to 'logger' in the document (not at import)
2. add 'logger = logging.getLogger(__name__)' after import